### PR TITLE
Fix build process and corrected install call in Readme

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Authors@R: c(
     person('Thomas', 'Travison', role = 'aut'),
     person('Wanting', 'Yu', role = 'ctb'),
     person('Brad', 'Manor', role = 'aut'),
-    person('Tod', 'Kurt', role = 'aut'),
+    person('Tod', 'Kurt', role = 'aut')
     )
 Description: Simple C based library for easily reading serial ports. It works 
     on any POSIX-compatible system, including Mac OS and Linux. 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ I'm working on getting this [libserialport](https://sigrok.org/wiki/Libserialpor
 
 # Installation
 ```r
-devtools::install("r-arduino/arduinor")
+devtools::install_github("r-arduino/arduinor")
 ```
 
 # Getting Started


### PR DESCRIPTION
This PR only changes two lines:
First in the DESCRIPTION file an extra comma is removed (with this extra comma, the package build fails). 
Second, in the Readme, the `devtools::install` call is replaced with `devtools::install_github` to allow users to install the package from github instead of having to download the files manually.

---

Otherwise, I love the package and what it does. It works perfectly on my Ubunut machine and helps me to understand the sensors on my Arduino. Keep up the good work!